### PR TITLE
[ADD] Adiciona scroll de rolagem para notificações não lidas #162

### DIFF
--- a/webapp/src/modules/notificacao/NotificacaoBadge.vue
+++ b/webapp/src/modules/notificacao/NotificacaoBadge.vue
@@ -32,18 +32,13 @@
                     </v-card-title>
 
                     <v-list
-                        v-if="notificacoesBadge != null && notificacoesBadge.length > 0"
-                        id="scroll-notificacoes"
-                        style="max-height: 250px"
-                        class="scroll-y">
+                        v-if="notificacoesBadge != null && notificacoesBadge.length > 0">
                         <template
                             v-for="(minhaNotificacao, indexNotificacao) in notificacoesBadge">
                             <v-list-tile
                                 :key="indexNotificacao"
                                 :to="minhaNotificacao"
-                                v-if="minhaNotificacao.is_notificacao_lida == false"
-                                v-scroll:#scroll-notificacoes="scrollNotificacoes">
-
+                                v-if="indexNotificacao < 4 && minhaNotificacao.is_notificacao_lida == false">
                                 <v-list-tile-content>
                                     <v-list-tile-title>[{{ minhaNotificacao.sistema }}]</v-list-tile-title>
                                     <v-list-tile-sub-title>{{ minhaNotificacao.titulo }}</v-list-tile-sub-title>
@@ -216,7 +211,6 @@ export default {
     name: 'NotificacaoBadge',
     data() {
         return {
-            scrollItens: 0,
             dialog: false,
             dialogNotificacao: false,
             notificacao: {},
@@ -301,9 +295,6 @@ export default {
         notificacaoLida(item) {
             this.lerNotificacao(item);
             this.dialogNotificacao = false;
-        },
-        scrollNotificacoes(e) {
-            this.scrollItens = e.target.scrollTop
         },
     },
 };

--- a/webapp/src/modules/notificacao/NotificacaoBadge.vue
+++ b/webapp/src/modules/notificacao/NotificacaoBadge.vue
@@ -34,7 +34,7 @@
                     <v-list
                         v-if="notificacoesBadge != null && notificacoesBadge.length > 0"
                         id="scroll-notificacoes"
-                        style="max-height: 200px"
+                        style="max-height: 250px"
                         class="scroll-y">
                         <template
                             v-for="(minhaNotificacao, indexNotificacao) in notificacoesBadge">

--- a/webapp/src/modules/notificacao/NotificacaoBadge.vue
+++ b/webapp/src/modules/notificacao/NotificacaoBadge.vue
@@ -31,31 +31,39 @@
                         Notificações
                     </v-card-title>
 
-                    <v-list v-if="notificacoesBadge != null && notificacoesBadge.length > 0">
-                        <v-list-tile
-                            v-for="(minhaNotificacao, indexNotificacao) in notificacoesBadge"
-                            :key="indexNotificacao"
-                            :to="minhaNotificacao">
+                    <v-list
+                        v-if="notificacoesBadge != null && notificacoesBadge.length > 0"
+                        id="scroll-notificacoes"
+                        style="max-height: 200px"
+                        class="scroll-y">
+                        <template
+                            v-for="(minhaNotificacao, indexNotificacao) in notificacoesBadge">
+                            <v-list-tile
+                                :key="indexNotificacao"
+                                :to="minhaNotificacao"
+                                v-if="minhaNotificacao.is_notificacao_lida == false"
+                                v-scroll:#scroll-notificacoes="scrollNotificacoes">
 
-                            <v-list-tile-content v-if="indexNotificacao < 4 && minhaNotificacao.is_notificacao_lida == false">
-                                <v-list-tile-title>[{{ minhaNotificacao.sistema }}]</v-list-tile-title>
-                                <v-list-tile-sub-title>{{ minhaNotificacao.titulo }}</v-list-tile-sub-title>
-                            </v-list-tile-content>
+                                <v-list-tile-content>
+                                    <v-list-tile-title>[{{ minhaNotificacao.sistema }}]</v-list-tile-title>
+                                    <v-list-tile-sub-title>{{ minhaNotificacao.titulo }}</v-list-tile-sub-title>
+                                </v-list-tile-content>
 
-                            <v-list-tile-action>
-                                <v-tooltip bottom>
-                                    <v-btn
-                                        slot="activator"
-                                        flat
-                                        icon
-                                        @click="showItem(minhaNotificacao)"
-                                    >
-                                        <v-icon>visibility</v-icon>
-                                    </v-btn>
-                                    <span>Visualizar Notificação</span>
-                                </v-tooltip>
-                            </v-list-tile-action>
-                        </v-list-tile>
+                                <v-list-tile-action>
+                                    <v-tooltip bottom>
+                                        <v-btn
+                                            slot="activator"
+                                            flat
+                                            icon
+                                            @click="showItem(minhaNotificacao)"
+                                        >
+                                            <v-icon>visibility</v-icon>
+                                        </v-btn>
+                                        <span>Visualizar Notificação</span>
+                                    </v-tooltip>
+                                </v-list-tile-action>
+                            </v-list-tile>
+                        </template>
                     </v-list>
 
                     <v-card-text v-else-if="notificacoesBadge != null && notificacoesBadge.length === 0">
@@ -208,6 +216,7 @@ export default {
     name: 'NotificacaoBadge',
     data() {
         return {
+            scrollItens: 0,
             dialog: false,
             dialogNotificacao: false,
             notificacao: {},
@@ -292,6 +301,9 @@ export default {
         notificacaoLida(item) {
             this.lerNotificacao(item);
             this.dialogNotificacao = false;
+        },
+        scrollNotificacoes(e) {
+            this.scrollItens = e.target.scrollTop
         },
     },
 };


### PR DESCRIPTION
Colocando scroll de rolagem para mostrar as notificações não lidas independente da quantidade e resolvendo o problema da visualização da issue #162 
![image](https://user-images.githubusercontent.com/28310065/55409648-c6011500-5538-11e9-8fd7-881aef440c36.png)
